### PR TITLE
Increase max-nesting-depth (scss)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     "font-family-name-quotes": "always-where-recommended",
     "selector-attribute-quotes": "always",
     "max-nesting-depth": [
-      3,
+      4,
       {
         ignore: ["pseudo-classes"],
       },


### PR DESCRIPTION
In order to avoid such situations (see below), where we have scss depth 4, but actually in css we have depth 2 I would suggest increasing of max-nesting-depth to 4.

`scss:
.news2021 {
  &-other-news {
    &__icon {
      &--previous {
        svg {
          transform: rotate(180deg);
        }        
      }
    }
  }
}`


css:
`.news2021-other-news__icon--previous svg {
  transform: rotate(180deg);
}`
